### PR TITLE
Drops side-effectful code

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,29 +1,46 @@
-# Reflex, a tiny React
+<h2 align="center">
+Reflex, a tiny react
 
-For learning purposes, I challenged myself to write a working React version with its minimal functionalities. It wasn't an inspiration/copy of the current algorithms and decisions that are used in production React. Modus-operandi is: map API surface and behavior, implement myself here, and later contrast with production React's implementations. The idea is to slowly converge to those, as mistakes are made.
+⚛️ 🤏
+</h2>
+
+For learning purposes, I challenged myself to write a small, naive, but working react. With its core functionalities.
+
+The goal is to gradually, on my own, slowly converge to the design that is used in React's production code. Of course, with big constraints to make it feasible.
 
 ## Features 
 
-Current state of affairs it supports:
+The end goal is to provide a useful, but not optimized reactivity library.
 
-- JSX elements (thanks, `tsc`)
-- Functional components
-- Reactivity through `useState` and propagated through props
-- Reconciles and re-paints only the sub-tree that had state changes
+Currently features:
+
+- Support for JSX
+- Support for functional components
+- State and reactivity provided by `useState` hook and props propagation
+- Efficient scheduling by delegating control back to main thread on fixed intervals
+
+## Running
+
+As simple as a
+
+```sh
+yarn dev
+```
 
 An example app is located at `src/App.tsx`.
 
-## To-do list
 
-Biggest caveats that should be solved for the scope of this project:
+## Upcoming
 
-- [x] Improve re-render API –– right now it relies on raw JSX parsing and execution to re-render
-- [x] Improve the reconciler algorithm –– right now is a full tree re-render at any state change
-- [x] Refactor reconciler to allow work suspense; inspire in a Fibery approach and adopt unit of works coupled to linked lists to achieve that
-- [x] Refactor how traversal is made; right now it relies on JSX's default post-order traversal; a BFS would be much more efficient to prevent from components higher in the tree from partial evaluation
-- [] Optimize reconciler fiber diff: as of now it always creates a new fiber on every pass
-- [] Optimize commits to only happen on necessary tree branches
-- [] Maintain a clear state between re-renders as to not break interactivity e.g. maintain focus state
-- [] Synchronize the paints with the browser
-- [] Support for useEffect
-- [] Support for useRef 
+What is missing:
+
+- Efficient rendering and painting: only on the sub-tree that had state changes
+- Smart reconciliation that does work only when needed (on a Fiber's state dispatcher subtree or when props have changed; usage of alternate prop)
+- Side effects through `useEffect` hook
+- Preserve interactivity states between re-renders (active focus, navigation)
+
+Chore:
+
+- Optimize commit-traversal algorithm
+- Improve scheduler through counters (inspired by production React)
+

--- a/src/core/react-dom/createElementWithProps.ts
+++ b/src/core/react-dom/createElementWithProps.ts
@@ -1,6 +1,6 @@
 import { Step, trace } from "../trace";
-import { Fiber } from "../types";
-import { createStateElementDispatcher } from "../react/fiber";
+import { Fiber, FiberType } from "../types";
+import { createStateElementDispatcher } from "../react/workLoop";
 
 function setNestedObjectProp(
   element: HTMLElement,
@@ -26,9 +26,9 @@ createStateElementDispatcher.setDispatcher(function createElementWithProps(
     "[Traversing VirtualDOM] [createElementWithProps] ",
     fiber
   );
-  // On leafs, we eventually hit primitive values
-  if (fiber?.text) {
-    return document.createTextNode(String(fiber.text));
+  // On leaves, we eventually hit primitive values i.e. data
+  if (fiber.type === FiberType.TextNode && fiber?.data) {
+    return document.createTextNode(String(fiber.data));
   }
 
   const { tag, props } = fiber;

--- a/src/core/react/createElement.ts
+++ b/src/core/react/createElement.ts
@@ -1,8 +1,26 @@
 import { trace, Step } from "../trace";
 
 import { SetState, StateBox } from "../types";
-import { scheduleFullRender } from "./fiber";
-import { createFiber } from "./createFiber";
+import { scheduleFullRender } from "./workLoop";
+
+function createReactElement({
+  tag,
+  props,
+  children,
+}: {
+  tag: string | Function | number;
+  props: any;
+  children: Array<object>;
+}) {
+  let element = {
+    type: undefined,
+    tag,
+    props,
+    children,
+  };
+
+  return element;
+}
 
 /*
   Use JSX to define our components.
@@ -28,7 +46,7 @@ function createElement(
   props: object,
   ...children: any[]
 ) {
-  return createFiber({ tag, props, children });
+  return createReactElement({ tag, props, children });
 }
 
 let hooks: StateBox[] = [];

--- a/src/core/react/index.ts
+++ b/src/core/react/index.ts
@@ -2,5 +2,5 @@ export {
   setCurrentRoot,
   commitDispatcher,
   createStateElementDispatcher,
-} from "./fiber";
-export { default as React } from "./react";
+} from "./workLoop";
+export { default as React } from "./createElement";

--- a/src/core/react/reconcileFiber.ts
+++ b/src/core/react/reconcileFiber.ts
@@ -1,0 +1,112 @@
+import { Step, trace } from "../trace";
+import { Fiber, Element, FunctionComponent, FiberType, Mode } from "../types";
+import { createFiber } from "./createFiber";
+
+function isFiber(node: Element | Fiber): node is Fiber {
+  return "alternate" in node && !!(node as Fiber).alternate;
+}
+
+function updateChildrenReferences(node: Element | Fiber): Fiber {
+  const children = (node.children ?? []) as Element[];
+  if (isFiber(node) && node.mode === Mode.Visited) {
+    // Bail early
+    return node;
+  }
+
+  let fiber = isFiber(node) ? (node as Fiber) : createFiber(node as Element);
+  let currentFiber: undefined | Fiber;
+  // Create child/parent/sibling relationships
+  for (let i = 0; i < children.length; i++) {
+    if (i === 0) {
+      fiber.child = createFiber(children[i]);
+      currentFiber = fiber.child;
+    }
+
+    if (currentFiber) {
+      if (children?.[i + 1]) {
+        currentFiber.sibling = createFiber(children[i + 1]);
+      }
+
+      trace(Step.CreateFiberReferences, "Creating refs for ", children[i]);
+      // Create parent ref
+      currentFiber.parent = fiber;
+      if (currentFiber.sibling) {
+        currentFiber = currentFiber.sibling;
+      }
+    }
+  }
+  // TODO: Mode is now useless; use it to tag edited nodes
+  trace(Step.CreateFiberReferences, "End of process for ", node);
+  return fiber;
+}
+
+function rerenderFiber(node: Fiber) {
+  if (!node.data || typeof node.data !== "function") {
+    return node;
+  }
+  const Component = node.data as FunctionComponent;
+
+  const {
+    children: renderChildren,
+    props: renderProps,
+    tag: renderTag,
+  } = Component(node.props);
+
+  node.children = renderChildren;
+  node.initialProps = node.props;
+  node.props = renderProps;
+  node.tag = renderTag;
+
+  trace(Step.UpdateFiber, "Re-rendering FunctionComponent – Fiber ", node);
+  return node;
+}
+
+function rerenderElement(node: Element): Element {
+  const Component = node.tag;
+  const {
+    children: renderChildren,
+    props: renderProps,
+    tag: renderTag,
+  } = Component(node.props);
+
+  // TODO: Compare renderProps and props
+  node.tag = renderTag;
+  node.children = renderChildren;
+  node.props = renderProps;
+  trace(Step.UpdateFiber, "Re-rendering FunctionComponent – Element ", node);
+  return node;
+}
+
+function reconcileFiber(node: Fiber | Element): Fiber {
+  let fiber;
+  trace(Step.UpdateFiber, "Incoming: ", node);
+  if (isFiber(node)) {
+    // We have already created the fiber. We are either in a re-render
+    // or re-visiting this fiber.
+    switch (node.type) {
+      case FiberType.FunctionComponent:
+        // Here is where we should place the re-render optimizations.
+        fiber = rerenderFiber(node);
+        break;
+      case FiberType.HostComponent:
+        fiber = node;
+        break;
+      case FiberType.TextNode:
+      default:
+        fiber = node;
+        break;
+    }
+  } else {
+    switch (typeof node.tag) {
+      case "function":
+        fiber = rerenderElement(node);
+        break;
+      default:
+        fiber = node;
+        break;
+    }
+  }
+  return updateChildrenReferences(fiber);
+}
+
+export { reconcileFiber };

--- a/src/core/trace.ts
+++ b/src/core/trace.ts
@@ -24,9 +24,10 @@ const decodeStep = (step: Step) => {
 
 // Change this to control what's being logged
 const LogLevel =
-  // Step.CreateFiberReferences |
+  Step.CreateFiberReferences |
   // Step.UpdateFiber |
-  // Step.WorkLoop |
+  Step.WorkLoop |
+  Step.Commit |
   Step.ExecuteUoW;
 
 export const trace = (step: Step, ...msg: any[]) => {

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -7,23 +7,36 @@ type StateBox<T = any> = {
   setState: SetState<T>;
 };
 
-type Fiber = {
-  // JSX attrs
-  tag?: string | Function;
-  props?: object;
-  children?: Fiber[];
+enum FiberType {
+  FunctionComponent = "FunctionComponent",
+  HostComponent = "HostComponent",
+  TextNode = "TextNode",
+}
 
-  // Function elements:
-  Component?: FunctionComponent;
-  initialProps?: object;
-  // Text elements:
-  text?: string; // TODO: Needs a better abstraction
+type Element = {
+  children: Element[];
+  props: object;
+  tag: any;
+};
+
+type Fiber = {
+  child: Fiber | undefined;
+  alternate: Fiber | undefined;
+  // TODO: Smells to have children and child.
+  children: Element[];
+  parent: Fiber | undefined;
+  sibling: Fiber | undefined;
+
+  initialProps: object | undefined;
+  // TODO: Children needs to be encapsulated inside props.
+  props: object | undefined;
+
+  data: FunctionComponent | string | undefined;
+  mode: Mode;
+  tag: string | Function;
+  type: FiberType;
+
   stateElement?: HTMLElement | Text;
-  mode?: Mode;
-  // Relationships
-  child?: Fiber;
-  sibling?: Fiber;
-  parent?: Fiber;
 };
 
 type FiberMachine = {
@@ -31,7 +44,13 @@ type FiberMachine = {
   next: undefined | Fiber;
 };
 
+type ElementMachine = {
+  current: undefined | Fiber | Element;
+  next: undefined | Fiber;
+};
+
 enum Mode {
+  Created = "CREATED",
   Visited = "VISITED",
   Completed = "COMPLETED",
 }
@@ -39,11 +58,14 @@ enum Mode {
 type FunctionComponent = (...props: any[]) => Fiber;
 
 export {
-  SetState,
-  Reducer,
-  StateBox,
+  Element,
+  ElementMachine,
   Fiber,
   FiberMachine,
-  Mode,
+  FiberType,
   FunctionComponent,
+  Mode,
+  Reducer,
+  SetState,
+  StateBox,
 };


### PR DESCRIPTION
Until now, most of the work loop, fiber creation and reconciliation relied on in-place memory modification. Which makes the code unnecessarily complex and increases the likelihood of messing things up and makes testing a mocking pain.

This change drops it for a functional approach, with the exception of `unitOfWork` and `root` pointers.